### PR TITLE
Whitelist productsign, pkgbuild and productbuild

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ const main = async () => {
         const importCommands = [
             ['security', ['default-keychain', '-s', keychainName]],
             ['security', ['unlock-keychain', '-p', keychainPassword, keychainName]],
-            ['security', ['import', certificatePath, '-f', 'pkcs12', '-k', keychainName, '-P', certificatePassphrase, '-T', '/usr/bin/codesign', '-x' ]],
+            ['security', ['import', certificatePath, '-f', 'pkcs12', '-k', keychainName, '-P', certificatePassphrase, '-T', '/usr/bin/codesign', '-T', '/usr/bin/productsign', '-T', '/usr/bin/pkgbuild', '-T', '/usr/bin/productbuild', '-x' ]],
             ['security', ['set-key-partition-list', '-S', 'apple-tool:,apple:', '-s', '-k', keychainPassword, keychainName]]
         ]
 


### PR DESCRIPTION
`codesign` is used only to sign applications/code.

To sign a `.pkg`/installer may be used `productsign` tool or `pkgbuild` + `productbuild` with a `--sign` parameter.